### PR TITLE
Bug fix: exact match was not working when case sensitivity is off

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wildstring",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Simple String Wildcard Handling",
   "main": "wildstring.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,27 @@ describe('wildstring - node', function() {
   		// Then: we should see that they match
   		assert.equal(result, true);
   	});
+	  
+  	it('should match exactly when no wildcard is given (case sensitivity is off)', function() {
+		// Before test: copy settings
+		var caseSensitive = wildstring.caseSensitive;
+		
+  		// Given: a string and a pattern that match and case sensitivity is off
+		wildstring.caseSensitive = false;
+  		var pattern = 'test',
+  				string = 'TEsT';
 
+  		// When: we call wildcard.match
+  		var result = wildstring.match(pattern, string);
+
+  		// Then: we should see that they match
+  		assert.equal(result, true);
+		
+		// After test: restore settings
+		wildstring.caseSensitive = caseSensitive;
+  	});
+
+	  
   	it('should return false if the string doesn\'t match the pattern and no wildcard is given', function() {
   		// Given: a string and a pattern that don't match
   		var pattern = 'test',

--- a/wildstring.js
+++ b/wildstring.js
@@ -64,13 +64,14 @@ var wildstring = {
 	* @param {string} string The string to test for a match
 	*/
 	match: function (pattern, string) {
-		// if there are no wildcards, must be exact
-		if (pattern.indexOf(wildstring.wildcard) === -1) {
-			return pattern === string;
-		}
 		if (!wildstring.caseSensitive) {
 			pattern = pattern.toLowerCase();
 			string = string.toLowerCase();
+		}
+
+		// if there are no wildcards, must be exact
+		if (pattern.indexOf(wildstring.wildcard) === -1) {
+			return pattern === string;
 		}
 		var patternSubstrings = pattern.split(wildstring.wildcard);
 		


### PR DESCRIPTION
Bug fix: 
  Exact match was not working when case sensitivity is off

Added tests for this case.

```
wildstring.caseSensitive = false;
wildstring.match('user', 'USeR');  // is true
```